### PR TITLE
The app crashes when calling transition for view controllers.

### DIFF
--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -153,7 +153,7 @@
 	
 	ModalViewController *newController;
 	if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-		newController = [[ModalViewController alloc] initWithNibName:@"ModalViewController-iPad" bundle:nil];
+		newController = [[ModalViewController alloc] initWithNibName:@"ModalViewController~iPad" bundle:nil];
 	}
 	else {
 		newController = [[ModalViewController alloc] initWithNibName:@"ModalViewController" bundle:nil];


### PR DESCRIPTION
Change ModalViewController-iPad to ModalViewController~iPad to avoid crashing when calling transition for view controllers.
